### PR TITLE
PROP-1567 add Logging type class + project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.idea/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.history
+.cache
+.lib/

--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,24 @@
 import sbtrelease.ReleaseStateTransformations._
 
 name := "effect-util"
-organization := "com.ovoenergy"
-organizationName := "Ovo Energy"
-organizationHomepage := Some(url("http://www.ovoenergy.com"))
 scalaVersion := "2.12.6"
 
 resolvers += Resolver.sonatypeRepo("releases")
 
-val bintrayReleaseProcess = Seq(
+val bintrayReleaseProcess: Seq[ReleaseStep] = Seq(
+  releaseStepTask(test),
   inquireVersions,
   setReleaseVersion,
+  releaseStepTask(publish),
   commitReleaseVersion,
   setNextVersion,
   commitNextVersion
 )
 
 val common = Seq(
+  organization := "com.ovoenergy",
+  organizationName := "Ovo Energy",
+  organizationHomepage := Some(url("http://www.ovoenergy.com")),
   bintrayRepository := "maven",
   bintrayOrganization := Some("ovotech"),
   releaseCommitMessage := s"Setting version of ${name.value} to ${version.value} [ci skip]",

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,30 @@
+name := "effect-util"
+organization := "com.ovoenergy"
+organizationName := "Ovo Energy"
+organizationHomepage := Some(url("http://www.ovoenergy.com"))
+scalaVersion := "2.12.6"
+
+resolvers += Resolver.sonatypeRepo("releases")
+
+val common = Seq(
+  compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"),
+  "org.typelevel" %% "cats-effect" % sys.env.getOrElse("CATS_EFFECT_VERSION", "0.10.1"),
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+)
+
+scalacOptions ++= Seq(
+  "-unchecked",
+  "-deprecation",
+  "-encoding",
+  "utf8",
+  "-feature",
+  "-Xfatal-warnings",
+  "-language:higherKinds"
+)
+
+val logging = project
+  .settings(libraryDependencies ++= common ++ Seq(
+    "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"
+  ))
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import sbtrelease.ReleaseStateTransformations._
 
 name := "effect-util"
 organization := "com.ovoenergy"
@@ -7,14 +8,19 @@ scalaVersion := "2.12.6"
 
 resolvers += Resolver.sonatypeRepo("releases")
 
+val bintrayReleaseProcess = Seq(
+  inquireVersions,
+  setReleaseVersion,
+  commitReleaseVersion,
+  setNextVersion,
+  commitNextVersion
+)
+
 val common = Seq(
-  bintrayRepository := "maven-private",
+  bintrayRepository := "maven",
   bintrayOrganization := Some("ovotech"),
-  libraryDependencies ++= Seq(
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"),
-    "org.typelevel" %% "cats-effect" % sys.env.getOrElse("CATS_EFFECT_VERSION", "0.10.1"),
-    "org.scalatest" %% "scalatest" % "3.0.5" % "test"
-  ),
+  releaseCommitMessage := s"Setting version of ${name.value} to ${version.value}",
+  releaseProcess := bintrayReleaseProcess,
   scalacOptions ++= Seq(
     "-unchecked",
     "-deprecation",
@@ -23,6 +29,11 @@ val common = Seq(
     "-feature",
     "-Xfatal-warnings",
     "-language:higherKinds"
+  ),
+  libraryDependencies ++= Seq(
+    compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"),
+    "org.typelevel" %% "cats-effect" % sys.env.getOrElse("CATS_EFFECT_VERSION", "0.10.1"),
+    "org.scalatest" %% "scalatest" % "3.0.5" % "test"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 import sbtrelease.ReleaseStateTransformations._
 
-name := "effect-util"
-scalaVersion := "2.12.6"
 
 resolvers += Resolver.sonatypeRepo("releases")
 
@@ -16,6 +14,7 @@ val bintrayReleaseProcess: Seq[ReleaseStep] = Seq(
 )
 
 val common = Seq(
+  scalaVersion := "2.12.6",
   organization := "com.ovoenergy",
   organizationName := "Ovo Energy",
   organizationHomepage := Some(url("http://www.ovoenergy.com")),
@@ -38,6 +37,9 @@ val common = Seq(
     "org.scalatest" %% "scalatest" % "3.0.5" % "test"
   )
 )
+
+lazy val root = (project in file("."))
+  .settings(common :+ (name := "effect-util"))
 
 val logging = project
   .settings(common)

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val bintrayReleaseProcess = Seq(
 val common = Seq(
   bintrayRepository := "maven",
   bintrayOrganization := Some("ovotech"),
-  releaseCommitMessage := s"Setting version of ${name.value} to ${version.value}",
+  releaseCommitMessage := s"Setting version of ${name.value} to ${version.value} [ci skip]",
   releaseProcess := bintrayReleaseProcess,
   scalacOptions ++= Seq(
     "-unchecked",

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+
 name := "effect-util"
 organization := "com.ovoenergy"
 organizationName := "Ovo Energy"
@@ -7,24 +8,30 @@ scalaVersion := "2.12.6"
 resolvers += Resolver.sonatypeRepo("releases")
 
 val common = Seq(
-  compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"),
-  "org.typelevel" %% "cats-effect" % sys.env.getOrElse("CATS_EFFECT_VERSION", "0.10.1"),
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
-)
-
-scalacOptions ++= Seq(
-  "-unchecked",
-  "-deprecation",
-  "-encoding",
-  "utf8",
-  "-feature",
-  "-Xfatal-warnings",
-  "-language:higherKinds"
+  bintrayRepository := "maven-private",
+  bintrayOrganization := Some("ovotech"),
+  libraryDependencies ++= Seq(
+    compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"),
+    "org.typelevel" %% "cats-effect" % sys.env.getOrElse("CATS_EFFECT_VERSION", "0.10.1"),
+    "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+  ),
+  scalacOptions ++= Seq(
+    "-unchecked",
+    "-deprecation",
+    "-encoding",
+    "utf8",
+    "-feature",
+    "-Xfatal-warnings",
+    "-language:higherKinds"
+  )
 )
 
 val logging = project
-  .settings(libraryDependencies ++= common ++ Seq(
-    "ch.qos.logback" % "logback-classic" % "1.2.3",
-    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"
-  ))
+  .settings(common)
+  .settings(
+    libraryDependencies ++= Seq(
+      "ch.qos.logback" % "logback-classic" % "1.2.3",
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"
+    )
+  )
 

--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -1,0 +1,79 @@
+package com.ovoenergy.effect
+
+import cats.data.StateT
+import cats.effect.Sync
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.{Applicative, FlatMap, MonadError}
+import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.MDC
+
+import scala.language.higherKinds
+
+/**
+  * A type class representing the ability to log
+  * within some effect type F
+  */
+trait Logging[F[_]] {
+  def log(what: Logging.Log): F[Unit]
+}
+
+/**
+  * Our functional code doesn't want to be sprinkled with effectful log statements
+  * and it also doesn't want to be tied to the IO monad, so we define a type class for some F
+  * which permits logging, returning an unmodified value wrapped in a (presumably modified) F
+  * In production code we can use SLF4J and IO, in tests we can use a Writer[List[Log]]
+  */
+object Logging {
+
+  type Tags = Map[String, String]
+
+  sealed trait Log {
+    def tags: Map[String, String]
+  }
+
+  case class Debug(of: String, tags: Tags = Map.empty) extends Log
+  case class Info(of: String, tags: Tags  = Map.empty) extends Log
+  case class Error(of: String, tags: Tags = Map.empty) extends Log
+
+  // syntax to summon an instance
+  def apply[F[_]: Logging]: Logging[F] = implicitly
+
+  /**
+    * An instance of logging for a Sync[F] which just wraps the call
+    * to the underlying logger
+    */
+  //noinspection ConvertExpressionToSAM
+  def syncLogging[F[_]: Sync]: Logging[F] = new Logging[F] with LazyLogging {
+    def log(what: Log): F[Unit] = Sync[F].delay {
+      what.tags.foreach {
+        case (k, v) =>
+          MDC.put(k, v)
+      }
+      what match {
+        case Debug(content, _) => logger.debug(content)
+        case Info(content, _)  => logger.info(content)
+        case Error(content, _) => logger.error(content)
+      }
+      what.tags.foreach {
+        case (k, _) =>
+          MDC.remove(k)
+      }
+    }
+  }
+
+  /**
+    * Lift logging for an F with logging into logging for a StateT[F, S, A]
+    */
+  implicit def stateTLogging[F[_]: Logging: Applicative, S]: Logging[StateT[F, S, ?]] =
+    (what: Log) => StateT.liftF(Logging[F].log(what))
+
+  /**
+    * Syntax for attaching logging to an effect -
+    * the logging will run _before_ the effect is evaluated, so even if say your IO fails
+    * you'll get logs
+    */
+  implicit class LogSyntax[F[_]: Logging: FlatMap, A](i: F[A]) {
+    def log(l: Log): F[A] = Logging[F].log(l) >> i
+  }
+}

--- a/logging/src/test/scala/com/ovoenergy/effect/LoggingTest.scala
+++ b/logging/src/test/scala/com/ovoenergy/effect/LoggingTest.scala
@@ -1,0 +1,25 @@
+package com.ovoenergy.effect
+
+import cats.data.WriterT
+import cats.effect.IO
+import cats.instances.list._
+import cats.syntax.flatMap._
+import com.ovoenergy.effect.Logging.{Debug, Info, Log, _}
+import org.scalatest.{Matchers, WordSpec}
+
+class LoggingTest extends WordSpec with Matchers {
+
+  type LogWriter[A] = WriterT[IO, List[Log], A]
+  implicit val logging: Logging[LogWriter] = log => WriterT.tell(List(log))
+
+  "Logging syntax" should {
+
+    "Log before running the actual effect" in {
+      val message = Debug("Testing logging")
+      val toLog: LogWriter[Unit] = WriterT.liftF(IO.unit)
+      val expected = List(message, Info("boo"))
+      val events = (toLog >> Logging[LogWriter].log(Info("boo"))).log(message)
+      events.written.unsafeRunSync shouldEqual expected
+    }
+  }
+}

--- a/logging/version.sbt
+++ b/logging/version.sbt
@@ -1,0 +1,1 @@
+version := "1.0.0-SNAPSHOT"

--- a/logging/version.sbt
+++ b/logging/version.sbt
@@ -1,1 +1,1 @@
-version := "1.0.0-SNAPSHOT"
+version := "0.0.1-SNAPSHOT"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")


### PR DESCRIPTION
So this PR does the following

- Sets up multi project SBT so we can publish each utility into a separate jar
- Includes the basics for Bintray publishing + a version for each subproject
- Adds a logging type class (not 100% done yet but is a start)

The hope is to get this onto master & then set up a CircleCI build to release it.